### PR TITLE
Fix `hubot sushi me` returns invalid path

### DIFF
--- a/scripts/sushiyuki.coffee
+++ b/scripts/sushiyuki.coffee
@@ -11,9 +11,8 @@ printf = require 'printf'
 _      = require 'underscore'
 
 class Sushiyuki
-  @baseUrl =
-    "https://raw.githubusercontent.com/
-      naoya/hubot-sushiyuki/master/sushiyuki_images/"
+  constructor: ->
+    @baseUrl = "https://raw.githubusercontent.com/naoya/hubot-sushiyuki/master/sushiyuki_images/"
 
   sushiMap:
     yes: 1


### PR DESCRIPTION
Coffeescriptの公式playgroundでも動作しなかったので、動作するように変更しました。:sushi:

## Before

```
hubot> hubot sushi me
undefined26.png?20150610010859963
```

## After

```
hubot> hubot sushi me
https://raw.githubusercontent.com/naoya/hubot-sushiyuki/master/sushiyuki_images/26.png?20150610010210542
```