### PR TITLE
hubot sushi listコマンドを見やすくしました

### DIFF
--- a/scripts/sushiyuki.coffee
+++ b/scripts/sushiyuki.coffee
@@ -74,7 +74,15 @@ module.exports = (robot) ->
     msg.send sushiyuki.sushiMe("sneak")
 
   robot.respond /sushi list/i, (msg) ->
-    msg.send sushiyuki.emotions().join "\n"
+    MAX = 15
+    output = ''
+    count  = 1
+    for e in sushiyuki.emotions()
+      output +=  new Array(MAX - e.length).join(' ') + e
+      if count % 4 is 0
+        output += '\n'
+      count++
+    msg.send output
 
   robot.respond /sushi me ?(.*)/i, (msg) ->
     emote = msg.match[1]


### PR DESCRIPTION
`hubot sushi list`コマンドが全て一列で出力されて見づらかったので、4つで一行で表示されるよう調整し見やすくしました。
文字幅についてはPC上のSlackで使う分には問題ない長さだと思います。
マージのご検討よろしくお願いします。

![](https://i.gyazo.com/6345ce6781843f455742f072cbc6993d.png)
